### PR TITLE
refactor: integrate qt6 docs as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "template-docs/template-cpp14"]
 	path = template-docs/template-cpp14
 	url = git@github.com:apigear-io/template-cpp14.git
+[submodule "template-docs/template-qt6"]
+	path = template-docs/template-qt6
+	url = git@github.com:apigear-io/template-qtcpp.git

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,7 +42,8 @@ const config = {
   [
     'static',
     'template-docs/template-unreal/docs/static',
-    'template-docs/template-cpp14/docs/static'
+    'template-docs/template-cpp14/docs/static',
+    'template-docs/template-qt6/docs/static'
   ],
 
   presets: [
@@ -95,6 +96,15 @@ const config = {
       },
     ],
     [
+      '@docusaurus/plugin-content-docs',
+      {
+        id: 'template-qt6',
+        path: 'template-docs/template-qt6/docs/docs',
+        routeBasePath: 'template-qt6/docs',
+        sidebarPath: undefined,
+      },
+    ],
+    [
       require.resolve('docusaurus-lunr-search'),
       {
         highlightResult: true
@@ -125,6 +135,7 @@ const config = {
               {type: 'doc', docId: 'intro', label: 'ApiGear Core'},
               {type: 'doc', docsPluginId: 'template-cpp14', docId: 'intro', label: 'Template C++14'},
               {type: 'doc', docsPluginId: 'template-unreal', docId: 'intro', label: 'Template Unreal Engine'},
+              {type: 'doc', docsPluginId: 'template-qt6', docId: 'intro', label: 'Template Qt6'},
             ],
           },
           {


### PR DESCRIPTION
## 📑 Description
Integrate the Qt6 docs as separate topic

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->