### PR TITLE
docs: make general docs available at /docs/

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /
 ---
 
 # ApiGear Core

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -201,7 +201,7 @@ const config = {
             items: [
               {
                 label: 'Introduction',
-                to: '/docs/intro',
+                to: '/docs',
               },
               {
                 label: 'Quick Start',

--- a/src/sections/WorkflowSection.js
+++ b/src/sections/WorkflowSection.js
@@ -9,7 +9,7 @@ export default function WorkflowSection() {
         action: 'More about the workflow',
         imageDark: '/img/devcycle_dark.svg',
         imageLight: '/img/devcycle_light.svg',
-        link: '/docs/intro',
+        link: '/docs/',
     };
     return (
         <TextRight item={item} />


### PR DESCRIPTION
## 📑 Description
- Removing the `intro` appendix from the docs url. So general docs can now be found at `docs/` instead of `docs/intro`

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->