### PR TITLE
docs: add the rust template

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,3 +21,7 @@
 	path = template-docs/template-java
 	url = https://github.com/apigear-io/template-java.git
 	branch = main
+[submodule "template-docs/template-rust"]
+	path = template-docs/template-rust
+	url = https://github.com/apigear-io/template-rust.git
+	branch = main

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,7 +48,8 @@ const config = {
     'template-docs/template-cpp14/docs/static',
     'template-docs/template-qt6/docs/static',
     'template-docs/template-python/docs/static',
-    'template-docs/template-java/docs/static'
+    'template-docs/template-java/docs/static',
+    'template-docs/template-rust/docs/static'
   ],
 
   presets: [
@@ -157,6 +158,18 @@ const config = {
       },
     ],
     [
+      '@docusaurus/plugin-content-docs',
+      {
+        id: 'template-rust',
+        path: 'template-docs/template-rust/docs/docs',
+        routeBasePath: 'template-rust/docs',
+        sidebarPath: undefined,
+        editUrl: ({docPath}) =>
+          `https://github.com/apigear-io/template-rust/edit/main/docs/docs/${docPath}`,
+        showLastUpdateTime: false,
+      },
+    ],
+    [
       require.resolve('docusaurus-lunr-search'),
       {
         highlightResult: true
@@ -250,6 +263,7 @@ const config = {
               {type: 'doc', docsPluginId: 'template-qt6', docId: 'intro', label: 'Template Qt6'},
               {type: 'doc', docsPluginId: 'template-python', docId: 'intro', label: 'Template Python'},
               {type: 'doc', docsPluginId: 'template-java', docId: 'intro', label: 'Template Java'},
+              {type: 'doc', docsPluginId: 'template-rust', docId: 'intro', label: 'Template Rust'},
             ],
           },
           {


### PR DESCRIPTION
## Summary
Adds the **Rust** SDK template to the documentation site, alongside the other
technology templates.

- New git submodule `template-docs/template-rust` → `apigear-io/template-rust`.
- `docusaurus.config.js`: a `@docusaurus/plugin-content-docs` instance
  (`id: template-rust`, `routeBasePath: template-rust/docs`), its `static`
  directory, and a **Template Rust** entry in the navbar templates dropdown.

The Rust documentation itself lives in the template repo
(apigear-io/template-rust#10) under `docs/docs/` and was written to match the
C++17 docs (intro, quickstart, and per-feature pages for api, stubs, monitor,
olink, mqtt, nats).

Verified locally with `npm run build` — all Rust routes generate and there are
no broken links.

> **Note:** the submodule is currently pinned to the template-rust docs branch
> (apigear-io/template-rust#10). Retarget it to `main` once that PR merges:
> `git -C template-docs/template-rust fetch && git -C template-docs/template-rust checkout main && git add template-docs/template-rust`.
