### PR TITLE
fix(web): keep mobile nav drawer above page content

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -169,9 +169,33 @@ h3 {
 .navbar {
   background: var(--ifm-background-surface-color);
   border-bottom: 1px solid var(--custom-border-color);
-  backdrop-filter: blur(12px);
   box-shadow: none;
   transition: all 0.3s ease;
+}
+
+/*
+ * Frosted-glass blur via a pseudo-element instead of backdrop-filter on the
+ * .navbar itself.
+ *
+ * The mobile sidebar drawer (.navbar-sidebar) and its backdrop are
+ * position:fixed CHILDREN of .navbar. A backdrop-filter on .navbar would make
+ * it the containing block for those fixed children, clipping them to the
+ * navbar's height — the open menu then hides behind the page content and the
+ * page scrolls underneath, on every page.
+ *
+ * ::before is NOT an ancestor of those fixed children, so it blurs the full
+ * width of the bar without trapping them. z-index keeps it behind the nav
+ * links (but still above the page), matching where the filter used to sit.
+ * Nothing toggles, so there is no open/close animation glitch.
+ */
+.navbar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  pointer-events: none;
 }
 
 .navbar--fixed-top {


### PR DESCRIPTION
## Problem

On mobile / narrow viewports, opening the navbar hamburger menu left the menu **hidden behind the page content** (e.g. the landing page's first hero card), with the page still scrolling underneath — the menu was effectively unusable. This affected **every page**, landing and docs alike.

## Root cause

`.navbar` carried `backdrop-filter: blur(12px)` (the frosted-glass effect). The mobile sidebar drawer (`.navbar-sidebar`) and its dark backdrop (`.navbar-sidebar__backdrop`) are `position: fixed` **children of `.navbar`**, and per the CSS Filter Effects spec an element with `backdrop-filter ≠ none` becomes the **containing block for its fixed descendants**. So instead of filling the viewport, the drawer and backdrop were clipped to the navbar's ~64px height:

- the backdrop no longer dimmed/blocked the page → the page scrolled behind;
- the drawer was squashed → the menu appeared stuck behind the page content.

## Fix

Move the blur from `.navbar` to a `.navbar::before` pseudo-element:

```css
.navbar::before {
  content: '';
  position: absolute;
  inset: 0;
  z-index: -1;                /* behind the links, above the page */
  -webkit-backdrop-filter: blur(12px);
  backdrop-filter: blur(12px);
  pointer-events: none;
}
```

- `::before` is **not an ancestor** of the fixed sidebar, so it blurs the full-width bar **without** trapping it. `.navbar` no longer carries a filter, so the sidebar/backdrop size to the viewport again.
- `z-index: -1` keeps the blur behind the nav links but above the page — same frosted-glass look as before.
- Because nothing toggles the filter on open/close, there is **no animation glitch** (an earlier toggle-based fix collided with the navbar's `transition: all 0.3s`, causing a visible two-stage reveal; this approach removes the cause entirely).

## Verification

- CSS compiles cleanly (webpack HMR success, no errors).
- Root cause traced from Docusaurus theme source (`Navbar/Layout`) + Infima CSS + the W3C spec.
- ⚠️ A live headless-browser check wasn't possible in the authoring environment (no usable Chromium). **Please verify visually**: open the site, narrow the window below 997px (or use device toolbar), open the hamburger — the drawer should cover the full screen with no scroll-behind and a smooth single-stage slide-in. Worth a look in iOS Safari specifically.